### PR TITLE
Ignore credentials when targeting s3

### DIFF
--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -1744,7 +1744,7 @@ BEGIN
     SELECT 'The value for the parameter @Credential is not supported.', 16, 2
   END
 
-  IF @URL IS NOT NULL AND @Credential IS NULL AND NOT EXISTS(SELECT * FROM sys.credentials WHERE UPPER(credential_identity) = 'SHARED ACCESS SIGNATURE')
+  IF @URL IS NOT NULL AND @URL NOT LIKE 's3://%' AND @Credential IS NULL AND NOT EXISTS(SELECT * FROM sys.credentials WHERE UPPER(credential_identity) = 'SHARED ACCESS SIGNATURE')
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @Credential is not supported.', 16, 3


### PR DESCRIPTION
s3 doesn't use credentials in the same way that azure does. I needed to add this change to successfully backup.

Without this change, I received the following error:

Msg 50000, Level 16, State 3, Procedure master.dbo.DatabaseBackup, Line 2288 [Batch Start Line 6]
The value for the parameter @Credential is not supported.